### PR TITLE
Explicitly relative import all the modules. Python3 does not support …

### DIFF
--- a/kkbox_developer_sdk/album_fetcher.py
+++ b/kkbox_developer_sdk/album_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXAlbumFetcher(Fetcher):
     '''

--- a/kkbox_developer_sdk/api.py
+++ b/kkbox_developer_sdk/api.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from auth_flow import *
-from track_fetcher import *
-from artist_fetcher import *
-from album_fetcher import *
-from shared_playlist_fetcher import *
-from search_fetcher import *
-from chart_fetcher import *
-from new_release_category_fetcher import *
-from genre_station_fetcher import *
-from mood_station_fetcher import *
-from feature_playlist_fetcher import *
-from feature_playlist_category_fetcher import *
-from new_hits_playlist_fetcher import *
+from .auth_flow import *
+from .track_fetcher import *
+from .artist_fetcher import *
+from .album_fetcher import *
+from .shared_playlist_fetcher import *
+from .search_fetcher import *
+from .chart_fetcher import *
+from .new_release_category_fetcher import *
+from .genre_station_fetcher import *
+from .mood_station_fetcher import *
+from .feature_playlist_fetcher import *
+from .feature_playlist_category_fetcher import *
+from .new_hits_playlist_fetcher import *
 
 
 class KKBOXAPI:

--- a/kkbox_developer_sdk/artist_fetcher.py
+++ b/kkbox_developer_sdk/artist_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXArtistFetcher(Fetcher):
     '''

--- a/kkbox_developer_sdk/auth_flow.py
+++ b/kkbox_developer_sdk/auth_flow.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from http import *
-from access_token import *
+from .http import *
+from .access_token import *
 
 class KKBOXOAuth:
     '''

--- a/kkbox_developer_sdk/chart_fetcher.py
+++ b/kkbox_developer_sdk/chart_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXChartFetcher(Fetcher):
     '''

--- a/kkbox_developer_sdk/feature_playlist_category_fetcher.py
+++ b/kkbox_developer_sdk/feature_playlist_category_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXFeaturePlaylistCategoryFetcher(Fetcher):
     '''

--- a/kkbox_developer_sdk/feature_playlist_fetcher.py
+++ b/kkbox_developer_sdk/feature_playlist_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXFeaturePlaylistFetcher(Fetcher):
     '''

--- a/kkbox_developer_sdk/fetcher.py
+++ b/kkbox_developer_sdk/fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from http import *
+from .http import *
 
 def assert_access_token(func, *args):
         @functools.wraps(func)

--- a/kkbox_developer_sdk/genre_station_fetcher.py
+++ b/kkbox_developer_sdk/genre_station_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXGenreStationFetcher(Fetcher):
     '''

--- a/kkbox_developer_sdk/mood_station_fetcher.py
+++ b/kkbox_developer_sdk/mood_station_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXMoodStationFetcher(Fetcher):
     '''

--- a/kkbox_developer_sdk/new_hits_playlist_fetcher.py
+++ b/kkbox_developer_sdk/new_hits_playlist_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXNewHitsPlaylistFetcher(Fetcher):
     '''

--- a/kkbox_developer_sdk/new_release_category_fetcher.py
+++ b/kkbox_developer_sdk/new_release_category_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXNewReleaseCategoryFetcher(Fetcher):
     '''

--- a/kkbox_developer_sdk/search_fetcher.py
+++ b/kkbox_developer_sdk/search_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXSearchTypes:
     '''

--- a/kkbox_developer_sdk/shared_playlist_fetcher.py
+++ b/kkbox_developer_sdk/shared_playlist_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXSharedPlaylistFetcher(Fetcher):
     '''

--- a/kkbox_developer_sdk/track_fetcher.py
+++ b/kkbox_developer_sdk/track_fetcher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from fetcher import *
-from territory import *
+from .fetcher import *
+from .territory import *
 
 class KKBOXTrackFetcher(Fetcher):
     '''


### PR DESCRIPTION
Since Python3 does not support implicit relative import, the dot `.` must be added for all the relative imports.